### PR TITLE
Add Report awareness to ExplodeWeapon

### DIFF
--- a/OpenRA.Mods.AS/Traits/ExplodeWeapon.cs
+++ b/OpenRA.Mods.AS/Traits/ExplodeWeapon.cs
@@ -78,6 +78,9 @@ namespace OpenRA.Mods.AS.Traits
 				weapon.Impact(Target.FromPos(self.CenterPosition + localoffset), self,
 					self.TraitsImplementing<IFirepowerModifier>().Select(a => a.GetFirepowerModifier()).ToArray());
 
+				if (weapon.Report != null && weapon.Report.Any())
+					Game.Sound.Play(SoundType.World, weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
+
 				if (--burst > 0)
 					fireDelay = weapon.BurstDelay;
 				else


### PR DESCRIPTION
ExplodeWeapon plays sound specified by the weapon's Report configuration.
(Used in OP mod by Desolator's deployed state weapon)