### PR TITLE
Fix a wrong update regarding VictimScanRadius.

### DIFF
--- a/OpenRA.Mods.AS/Traits/Warheads/AttachDelayedWeaponWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/AttachDelayedWeaponWarhead.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.AS.Traits;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.AS.Warheads
@@ -61,6 +62,15 @@ namespace OpenRA.Mods.AS.Warheads
 					continue;
 
 				if (actor.IsDead)
+					continue;
+
+				var activeShapes = actor.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
+				if (!activeShapes.Any())
+					continue;
+
+				var distance = activeShapes.Min(t => t.Info.Type.DistanceFromEdge(pos, actor));
+
+				if (distance > Range)
 					continue;
 
 				var attachable = actor.TraitsImplementing<DelayedWeaponAttachable>().FirstOrDefault(a => a.CanAttach(Type));

--- a/OpenRA.Mods.AS/Traits/Warheads/AttachDelayedWeaponWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/AttachDelayedWeaponWarhead.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.AS.Traits;
+using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.AS.Warheads
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.AS.Warheads
 			if (!IsValidImpact(pos, firedBy))
 				return;
 
-			var availableActors = firedBy.World.FindActorsInCircle(pos, Range + VictimScanRadius);
+			var availableActors = firedBy.World.FindActorsOnCircle(pos, Range);
 			foreach (var actor in availableActors)
 			{
 				if (!IsValidAgainst(actor, firedBy))

--- a/OpenRA.Mods.AS/Traits/Warheads/CaptureActorWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/CaptureActorWarhead.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -49,7 +50,7 @@ namespace OpenRA.Mods.AS.Warheads
 			if (!IsValidImpact(pos, firedBy))
 				return;
 
-			var availableActors = firedBy.World.FindActorsInCircle(pos, Range + VictimScanRadius);
+			var availableActors = firedBy.World.FindActorsOnCircle(pos, Range);
 
 			foreach (var a in availableActors)
 			{

--- a/OpenRA.Mods.AS/Traits/Warheads/DetachDelayedWeaponWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/DetachDelayedWeaponWarhead.cs
@@ -8,11 +8,11 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.AS.Warheads;
 using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.AS.Traits.Warheads
@@ -46,6 +46,15 @@ namespace OpenRA.Mods.AS.Traits.Warheads
 					continue;
 
 				if (actor.IsDead)
+					continue;
+
+				var activeShapes = actor.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
+				if (!activeShapes.Any())
+					continue;
+
+				var distance = activeShapes.Min(t => t.Info.Type.DistanceFromEdge(pos, actor));
+
+				if (distance > Range)
 					continue;
 
 				var attachables = actor.TraitsImplementing<DelayedWeaponAttachable>();

--- a/OpenRA.Mods.AS/Traits/Warheads/DetachDelayedWeaponWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/DetachDelayedWeaponWarhead.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.AS.Warheads;
+using OpenRA.Mods.Common;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.AS.Traits.Warheads
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.AS.Traits.Warheads
 			if (!IsValidImpact(pos, firedBy))
 				return;
 
-			var availableActors = firedBy.World.FindActorsInCircle(pos, Range + VictimScanRadius);
+			var availableActors = firedBy.World.FindActorsOnCircle(pos, Range);
 			foreach (var actor in availableActors)
 			{
 				if (!IsValidAgainst(actor, firedBy))

--- a/OpenRA.Mods.AS/Traits/Warheads/FireShrapnelWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/FireShrapnelWarhead.cs
@@ -57,9 +57,9 @@ namespace OpenRA.Mods.AS.Warheads
 			if (!IsValidImpact(target.CenterPosition, firedBy))
 				return;
 
-			var directActors = world.FindActorsInCircle(target.CenterPosition, VictimScanRadius);
+			var directActors = world.FindActorsOnCircle(target.CenterPosition, WDist.Zero);
 
-			var availableTargetActors = world.FindActorsInCircle(target.CenterPosition, weapon.Range)
+			var availableTargetActors = world.FindActorsOnCircle(target.CenterPosition, weapon.Range)
 				.Where(x => (AllowDirectHit || !directActors.Contains(x))
 					&& weapon.IsValidAgainst(Target.FromActor(x), firedBy.World, firedBy)
 					&& AimTargetStances.HasStance(firedBy.Owner.Stances[x.Owner]))

--- a/OpenRA.Mods.AS/Traits/Warheads/FireShrapnelWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/FireShrapnelWarhead.cs
@@ -57,12 +57,38 @@ namespace OpenRA.Mods.AS.Warheads
 			if (!IsValidImpact(target.CenterPosition, firedBy))
 				return;
 
-			var directActors = world.FindActorsOnCircle(target.CenterPosition, WDist.Zero);
+			var directActors = world.FindActorsOnCircle(target.CenterPosition, WDist.Zero)
+				.Where(a =>
+				{
+					var activeShapes = a.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
+					if (!activeShapes.Any())
+						return false;
+
+					var distance = activeShapes.Min(t => t.Info.Type.DistanceFromEdge(target.CenterPosition, a));
+
+					if (distance != WDist.Zero)
+						return false;
+
+					return true;
+				});
 
 			var availableTargetActors = world.FindActorsOnCircle(target.CenterPosition, weapon.Range)
 				.Where(x => (AllowDirectHit || !directActors.Contains(x))
 					&& weapon.IsValidAgainst(Target.FromActor(x), firedBy.World, firedBy)
 					&& AimTargetStances.HasStance(firedBy.Owner.Stances[x.Owner]))
+				.Where(x =>
+				{
+					var activeShapes = x.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
+					if (!activeShapes.Any())
+						return false;
+
+					var distance = activeShapes.Min(t => t.Info.Type.DistanceFromEdge(target.CenterPosition, x));
+
+					if (distance < weapon.Range)
+						return true;
+
+					return false;
+				})
 				.Shuffle(world.SharedRandom);
 
 			var targetActor = availableTargetActors.GetEnumerator();

--- a/OpenRA.Mods.AS/Traits/Warheads/PromotionWarhead.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/PromotionWarhead.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.AS.Warheads
 			if (!IsValidImpact(pos, firedBy))
 				return;
 
-			var availableActors = firedBy.World.FindActorsInCircle(pos, Range + VictimScanRadius);
+			var availableActors = firedBy.World.FindActorsOnCircle(pos, Range);
 
 			foreach (var a in availableActors)
 			{

--- a/OpenRA.Mods.AS/Traits/Warheads/WarheadAS.cs
+++ b/OpenRA.Mods.AS/Traits/Warheads/WarheadAS.cs
@@ -23,10 +23,6 @@ namespace OpenRA.Mods.AS.Warheads
 		"These warheads check for the Air TargetType when detonated inair!")]
 	public abstract class WarheadAS : Warhead
 	{
-		[Desc("Extra search radius beyond maximum spread. If set to zero (default), it will automatically scale to the largest health shape.",
-			"Custom overrides should not be necessary under normal circumstances.")]
-		public WDist VictimScanRadius = WDist.Zero;
-
 		public ImpactType GetImpactType(World world, CPos cell, WPos pos, Actor firedBy)
 		{
 			// Missiles need a margin because they sometimes explode a little above ground
@@ -48,7 +44,7 @@ namespace OpenRA.Mods.AS.Warheads
 
 		public bool GetDirectHit(World world, CPos cell, WPos pos, Actor firedBy, bool checkTargetType = false)
 		{
-			foreach (var victim in world.FindActorsInCircle(pos, VictimScanRadius))
+			foreach (var victim in world.FindActorsOnCircle(pos, WDist.Zero))
 			{
 				if (checkTargetType && !IsValidAgainst(victim, firedBy))
 					continue;


### PR DESCRIPTION
NTM - This is currently wrong, because it increases ranges of all warheads indirectly based on largest actor radius.