### PR TITLE
Added TargetString to IIssueDeployOrder

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -149,7 +149,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self, bool queued)
 		{
-			return new Order("GrantConditionOnDeploy", self, queued);
+			var gcodorder = new Order("GrantConditionOnDeploy", self, queued);
+			if (Info.SynchronizeDeployment)
+			{
+				var actors = self.World.Selection.Actors.Select(x => x.ActorID.ToString());
+				gcodorder.TargetString = string.Join(",", actors);
+			}
+
+			return gcodorder;
 		}
 
 		bool IIssueDeployOrder.CanIssueDeployOrder(Actor self) { return !IsTraitPaused && !IsTraitDisabled; }


### PR DESCRIPTION
The previous fix worked. Technically. The only problem is that if the Hotkey was pressed to send the deploy order, the IssueOrder function was never invoked. IssueOrder seems to only be invoked when the unit is clicked with the cursor. The primary way that these SynchronizedDeployment orders will be sent is going to be through IIssueDeployOrder.IssueDeployOrder. 