### PR TITLE
Smart deploy patch

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool CanDeployOnRamps = false;
 
 		[Desc("Does this actor need to synchronize it's deployment with other actors?")]
-		public readonly bool SynchronizeDeployment = false;
+		public readonly bool SmartDeploy = false;
 
 		[Desc("Cursor to display when able to (un)deploy the actor.")]
 		public readonly string DeployCursor = "deploy";
@@ -141,7 +141,8 @@ namespace OpenRA.Mods.Common.Traits
 			return new Order("GrantConditionOnDeploy", self, queued);
 		}
 
-		bool IIssueDeployOrder.CanIssueDeployOrder(Actor self) {
+		bool IIssueDeployOrder.CanIssueDeployOrder(Actor self)
+		{
 			if (!IsTraitPaused && !IsTraitDisabled && IsGroupDeployNeeded(self))
 				return true;
 			else
@@ -150,10 +151,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IsGroupDeployNeeded(Actor self)
 		{
-			var actors = self.World.Selection.Actors;
-
-			if (!Info.SynchronizeDeployment)
+			if (!Info.SmartDeploy)
 				return true;
+
+			var actors = self.World.Selection.Actors;
 
 			int deployedCount = 0;
 			int undeployedCount = 0;
@@ -169,15 +170,15 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (gcod != null && (gcod.DeployState == DeployState.Undeploying || gcod.DeployState == DeployState.Undeployed))
 					undeployedCount += 1;
-			}
 
-			if (deployedCount > 0 && undeployedCount > 0)
-			{
-				var gcod = self.TraitOrDefault<GrantConditionOnDeploy>();
-				if (gcod.DeployState == DeployState.Undeploying || gcod.DeployState == DeployState.Undeployed)
-					return true;
+				if (deployedCount > 0 && undeployedCount > 0)
+				{
+					var self_gcod = self.TraitOrDefault<GrantConditionOnDeploy>();
+					if (self_gcod.DeployState == DeployState.Undeploying || self_gcod.DeployState == DeployState.Undeployed)
+						return true;
 
-				return false;
+					return false;
+				}
 			}
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -143,10 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IIssueDeployOrder.CanIssueDeployOrder(Actor self)
 		{
-			if (!IsTraitPaused && !IsTraitDisabled && IsGroupDeployNeeded(self))
-				return true;
-			else
-				return false;
+			return !IsTraitPaused && !IsTraitDisabled && IsGroupDeployNeeded(self);
 		}
 
 		bool IsGroupDeployNeeded(Actor self)
@@ -156,8 +153,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var actors = self.World.Selection.Actors;
 
-			int deployedCount = 0;
-			int undeployedCount = 0;
+			bool hasDeployedActors = false;
+			bool hasUndeployedActors = false;
 
 			foreach (var a in actors)
 			{
@@ -165,13 +162,13 @@ namespace OpenRA.Mods.Common.Traits
 				if (!a.IsDead && a.IsInWorld)
 					gcod = a.TraitOrDefault<GrantConditionOnDeploy>();
 
-				if (gcod != null && (gcod.DeployState == DeployState.Deploying || gcod.DeployState == DeployState.Deployed))
-					deployedCount += 1;
+				if (!hasDeployedActors && gcod != null && (gcod.DeployState == DeployState.Deploying || gcod.DeployState == DeployState.Deployed))
+					hasDeployedActors = true;
 
-				if (gcod != null && (gcod.DeployState == DeployState.Undeploying || gcod.DeployState == DeployState.Undeployed))
-					undeployedCount += 1;
+				if (!hasUndeployedActors && gcod != null && (gcod.DeployState == DeployState.Undeploying || gcod.DeployState == DeployState.Undeployed))
+					hasUndeployedActors = true;
 
-				if (deployedCount > 0 && undeployedCount > 0)
+				if (hasDeployedActors && hasUndeployedActors)
 				{
 					var self_gcod = self.TraitOrDefault<GrantConditionOnDeploy>();
 					if (self_gcod.DeployState == DeployState.Undeploying || self_gcod.DeployState == DeployState.Undeployed)

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -155,43 +155,32 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Info.SynchronizeDeployment)
 				return true;
 
-			int deployCount = 0;
-			int undeployCount = 0;
-			var mode = "undef";
-			bool deployNeeded = false;
+			int deployedCount = 0;
+			int undeployedCount = 0;
 
-			foreach(var a in actors)
+			foreach (var a in actors)
 			{
-				var gcod = a.TraitOrDefault<GrantConditionOnDeploy>();
+				GrantConditionOnDeploy gcod = null;
+				if (!a.IsDead && a.IsInWorld)
+					gcod = a.TraitOrDefault<GrantConditionOnDeploy>();
 
 				if (gcod != null && (gcod.DeployState == DeployState.Deploying || gcod.DeployState == DeployState.Deployed))
-					deployCount += 1;
+					deployedCount += 1;
 
 				if (gcod != null && (gcod.DeployState == DeployState.Undeploying || gcod.DeployState == DeployState.Undeployed))
-					undeployCount += 1;
+					undeployedCount += 1;
 			}
 
-			if (deployCount > 0 && undeployCount > 0)
-				mode = "mixed";
-
-			if (deployCount == 0 && undeployCount > 0)
-				mode = "undeployed";
-
-			if (deployCount > 0 && undeployCount == 0)
-				mode = "deployed";
-
-			if (mode == "mixed")
+			if (deployedCount > 0 && undeployedCount > 0)
 			{
 				var gcod = self.TraitOrDefault<GrantConditionOnDeploy>();
 				if (gcod.DeployState == DeployState.Undeploying || gcod.DeployState == DeployState.Undeployed)
 					return true;
 
 				return false;
-			
 			}
 
 			return true;
-
 		}
 
 		public void ResolveOrder(Actor self, Order order)


### PR DESCRIPTION
This chief purpose of this patch is to fix the desync glitch caused when shift queuing a smart deploy order. 
We are also no longer adding a target string to the gcod. 

All of the logic is handled within CanIssueDeployOrder method. This means that when a deploy order is sent to a group of units in a mixed deploy state, deploy orders will be issued only for the ones that need it. This logic is handled client side, should introduce less lag than the previous version, which introduced a targetString that grew on a factorial scale. I.E, if you have 100 units, you have 100 units each with a target string of 100 elements, or 1000 units, each with a target String of 1000 units. The amount of data sent across would be inordinately high when dealing with large groups of actors. 