### PR TITLE
Fix bug that mind control actor transforming

### DIFF
--- a/OpenRA.Mods.AS/Traits/MindController.cs
+++ b/OpenRA.Mods.AS/Traits/MindController.cs
@@ -145,6 +145,12 @@ namespace OpenRA.Mods.AS.Traits
 				UnstackControllingCondition(self, Info.ControllingCondition);
 		}
 
+		public void TransformSlave(Actor self, Actor oldSlave, Actor newSlave)
+		{
+			if (slaves.Contains(oldSlave))
+				slaves[slaves.FindIndex(o => o == oldSlave)] = newSlave;
+		}
+
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			ReleaseSlaves(self);


### PR DESCRIPTION
Authored by CastleJing
GIF on bug fix performance.
![fix](https://user-images.githubusercontent.com/13763394/77718945-1bbeaf00-701f-11ea-94e5-b5979d9b3ae4.gif)

P.S. If transformation target actor don't have "MindControllable" trait, then after transformation the new actor will return to orignal owner.