### PR TITLE
Fix uninitializing crash in FireArmamentPower

### DIFF
--- a/OpenRA.Mods.AS/Traits/SupportPowers/FireArmamentPower.cs
+++ b/OpenRA.Mods.AS/Traits/SupportPowers/FireArmamentPower.cs
@@ -85,6 +85,7 @@ namespace OpenRA.Mods.AS.Traits
 		{
 			facing = self.TraitOrDefault<IFacing>();
 			Armaments = self.TraitsImplementing<Armament>().Where(t => t.Info.Name.Contains(FireArmamentPowerInfo.ArmamentName)).ToArray();
+			activeArmaments = new HashSet<Armament>();
 
 			var armamentturrets = Armaments.Select(x => x.Info.Turret).ToHashSet();
 			turreted = self.TraitsImplementing<Turreted>().Where(x => armamentturrets.Contains(x.Name)).Count() > 0;


### PR DESCRIPTION
 I find crash again in FireArmamenPower. The "activeArmament" is uninitialized in "created()" and only initialize just before first usage of FireArmamenPower, which makes the game crash when unit with FireArmamenPower use other normal weapon first when created.